### PR TITLE
Remove item from inventory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ fn remove_inventory(inv: &mut std::vec::Vec<Item>, item_id: &str) {
     match item_idx {
         Some(idx) => {
             inv.remove(idx);
-            println!("Removed {}", idx);
+            println!("Item removed");
         }
         None => println!("Item not in inventory"),
     }


### PR DESCRIPTION
For now, user needs to input `remove`, and then is prompted for the name of the item to remove.
On a next iteration, it would be cool to just input `remove berries`.