### PR TITLE
Thread all the things!

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -168,18 +168,14 @@ fn control_time(days: &Arc<Mutex<i32>>, stats: &Arc<Mutex<Stats>>) {
     let days = Arc::clone(&days);
     let stats = Arc::clone(&stats);
     thread::spawn(move || loop {
+        thread::sleep(Duration::from_secs(10));
         let elapsed_time = now.elapsed().as_secs();
         let mut elapsed_days = days.lock().unwrap();
 
         *elapsed_days = elapsed_time as i32 / 60;
 
-        std::mem::drop(elapsed_days);
-
         let mut stats_lock = stats.lock().unwrap();
         decrease_stats(&mut stats_lock, 10.0);
-        std::mem::drop(stats_lock);
-
-        thread::sleep(Duration::from_secs(10));
     });
 }
 


### PR DESCRIPTION
Use threads for better time and stats control: now the game stops as soon as the stats reach to 0, instead of on the next user action.

A new thread loops every 10 seconds and decreases stats, as well as increases the day count if needed. Day count and stats are now Mutexes!

The main thread needs to keep checking if any of the stats has reached 0. I can't do it if it's blocked waiting for user input, so I had to move the `stdin` to a new thread. It waits until the main thread is ready to receive input, then requests input from the user, and when the user types an action it sends it to the main thread. Messages between threads are sent via channels.

So I got to experience with both ways to handle concurrency in a single feature. Yay!
